### PR TITLE
Adds Observable.toPromise (and .toFuture)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.10")

--- a/src/main/scala/rxjs/core/Observable.scala
+++ b/src/main/scala/rxjs/core/Observable.scala
@@ -16,6 +16,8 @@ trait Observable[T] extends js.Object {
   def subscribe[U<:T](onNext: js.Function1[U,Any],
                 onError: js.Function1[js.Dynamic,Any] = null,
                 onCompleted: js.Function0[Any] = null) = js.native
+
+  def toPromise(): js.Promise[T] = js.native
 }
 
 @JSName("Rx.Observable")

--- a/src/main/scala/rxjs/core/package.scala
+++ b/src/main/scala/rxjs/core/package.scala
@@ -4,8 +4,13 @@
 // Copyright (c) 2016. Distributed under the MIT License (see included LICENSE file).
 package rxjs
 
+import scala.concurrent.Future
 import scala.scalajs.js
 
 package object core {
   type Selector[T,U] = js.Function3[T,Int,Observable[T],U]
+
+  implicit class RichObservable[T](val obv: Observable[T]) {
+    def toFuture: Future[T] = obv.toPromise().toFuture
+  }
 }


### PR DESCRIPTION
I'm working on getting angulate2 fully supporting the Http module. This is an early step towards that.

https://angular.io/docs/ts/latest/tutorial/toh-pt6.html

In this tutorial: `http.get().toPromise()` is called. Currently that's impossible. The Observable returned doesn't have this method. I've added it.

It also seems like this hasn't been published in quite some time. The name exposed in the published version is `IObservable` but the code has simply `Observable` currently.
